### PR TITLE
update resolvePackage for commandbox-6 compat

### DIFF
--- a/endpoints/pixl8.cfc
+++ b/endpoints/pixl8.cfc
@@ -26,7 +26,7 @@ component accessors="true" implements="commandbox.system.endpoints.IEndpoint" {
 		return this;
 	}
 
-	public string function resolvePackage( required string package, boolean verbose=false ) {
+	public string function resolvePackage( required string package, string currentworkingdirectory, boolean verbose=false ) {
 		wirebox.getInstance( "interceptorService" ).registerInterceptor( this );
 
 		var job           = wirebox.getInstance( 'interactiveJob' );


### PR DESCRIPTION
Resolves the following error since the resolvePackage function signature has changed

```
ERROR (6.0.0+00787)

function [resolvepackage(string package, [boolean verbose])] of component [/Users/zac/.CommandBox/cfml/modules/pixl8-commandbox-commands/endpoints/pixl8.cfc] does not match the function declaration [resolvepackage(string package, [string currentworkingdirectory, [boolean verbose]])] of the abstract component/interface [/Users/zac/.CommandBox/cfml/system/endpoints/IEndpoint.cfc]

not the same argument count
/modules/pixl8-commandbox-commands/endpoints/pixl8.cfc: line 21
19: 	property name="fileResolver"     inject="commandbox.system.endpoints.file";
20:
21: 	property name="namePrefixes" type="string";
22:
23: 	function init() {
called from /modules/pixl8-commandbox-commands/endpoints/pixl8.cfc: line 10
called from /system/wirebox/system/core/util/Util.cfc: line 442
called from /system/wirebox/system/ioc/config/Mapping.cfc: line 521
called from /system/wirebox/system/cache/AbstractCacheBoxProvider.cfc: line 387
called from /system/wirebox/system/ioc/config/Mapping.cfc: line 530
called from /system/wirebox/system/ioc/Injector.cfc: line 409
called from /system/services/EndpointService.cfc: line 55
called from /system/services/ModuleService.cfc: line 492
called from /system/services/ModuleService.cfc: line 145
called from /system/services/PackageService.cfc: line 661
called from /system/modules_app/package-commands/commands/package/install.cfc: line 159
called from /system/services/CommandService.cfc: line 443
called from /system/services/CommandService.cfc: line 245
called from /system/Shell.cfc: line 862
called from /system/Bootstrap.cfm: line 124
```